### PR TITLE
SSH Monitor Reliability Improvements

### DIFF
--- a/ssh-log-monitor/README.md
+++ b/ssh-log-monitor/README.md
@@ -12,6 +12,10 @@ A Linux-compatible Go application that monitors `/var/log/auth.log` for SSH logi
 - Tracks last-read log position using an offset file
 - Lightweight and cron-compatible
 - Installable in 1 command using `curl`
+- Built-in timeout mechanism (5-minute max runtime)
+- Incremental offset tracking to prevent duplicate processing
+- Lock mechanism to prevent concurrent runs
+- Comprehensive logging with performance metrics
 
 ---
 
@@ -101,6 +105,30 @@ It will:
 - Skip previously seen lines (based on offset)
 - Extract IPs from SSH login attempts
 - Send logs to the gRPC server defined in `main.go`
+- Update the offset after processing each entry
+- Terminate after 5 minutes (if still running)
+
+---
+
+## 🔄 Reliability Features
+
+### Timeout Protection
+The application has a built-in 5-minute timeout to prevent indefinite execution. If the timeout is reached, the current progress is saved before termination.
+
+### Incremental Offset Tracking
+The offset file is updated after each log entry is processed, ensuring that even if the application is terminated prematurely:
+- No log entries are processed twice
+- Processing can resume exactly where it left off
+
+### Concurrent Run Prevention
+A lock mechanism ensures that only one instance of the application can run at a time, preventing race conditions when processing log entries.
+
+### Enhanced Logging
+Detailed logs provide insights into:
+- Processing progress and performance metrics
+- Connection status to the gRPC server
+- Errors and exceptional conditions
+- Partial progress during long-running tasks
 
 ---
 

--- a/ssh-log-monitor/main.go
+++ b/ssh-log-monitor/main.go
@@ -19,55 +19,86 @@ const (
 )
 
 func main() {
+	log.Println("🚀 Starting SSH log monitor...")
+	startTime := time.Now()
+
 	// Create a context with a 5-minute timeout
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
+	log.Printf("⏱️ Set execution timeout: %v", timeout)
 
 	// Acquire lock to prevent concurrent runs
+	log.Println("🔒 Attempting to acquire lock...")
 	if err := state.AcquireLock(); err != nil {
-		log.Fatalf("Failed to acquire lock: %v", err)
+		log.Fatalf("❌ Failed to acquire lock: %v", err)
 	}
+	log.Println("✅ Lock acquired successfully")
 	defer func() {
 		if err := state.ReleaseLock(); err != nil {
-			log.Printf("Failed to release lock: %v", err)
+			log.Printf("⚠️ Failed to release lock: %v", err)
+		} else {
+			log.Println("🔓 Lock released successfully")
 		}
 	}()
 
 	offset, err := state.ReadOffset(offsetPath)
 	if err != nil {
-		log.Fatalf("Failed to read offset: %v", err)
+		log.Fatalf("❌ Failed to read offset from %s: %v", offsetPath, err)
 	}
+	log.Printf("📋 Read offset: %d from %s", offset, offsetPath)
 
+	log.Printf("📖 Parsing auth log from %s starting at offset %d...", logPath, offset)
 	entries, newOffset, err := parser.ParseAuthLog(logPath, offset)
 	if err != nil {
-		log.Fatalf("Failed to parse auth.log: %v", err)
+		log.Fatalf("❌ Failed to parse auth.log: %v", err)
 	}
 
-	fmt.Printf("Scanned auth.log – Found %d entries | New offset: %d\n", len(entries), newOffset)
+	log.Printf("📊 Scan complete - Found %d entries | New offset: %d", len(entries), newOffset)
+	if len(entries) == 0 {
+		log.Println("ℹ️ No new SSH login attempts found, nothing to process")
+	} else {
+		log.Printf("🔍 Found %d SSH login attempts to process", len(entries))
+	}
+
 	for _, entry := range entries {
 		fmt.Printf("➡️ Found SSH login attempt from IP %s at %s\n", entry.IP, entry.Timestamp)
 	}
 
+	// Process entries with incremental offset updates
 	for i, entry := range entries {
+		currentOffset := offset + int64(i)
 		select {
 		case <-ctx.Done():
-			log.Printf("Timeout reached, stopping execution")
+			log.Printf("⚠️ Timeout reached after %v, stopping execution", time.Since(startTime))
 			// Write the last processed offset before exiting
-			if err := state.WriteOffset(offsetPath, offset+int64(i)); err != nil {
-				log.Printf("Failed to write offset: %v", err)
+			if err := state.WriteOffset(offsetPath, currentOffset); err != nil {
+				log.Printf("❌ Failed to write final offset %d: %v", currentOffset, err)
+			} else {
+				log.Printf("💾 Saved partial progress: offset updated to %d before timeout", currentOffset)
 			}
 			return
 		default:
-			log.Printf("Sending log for IP %s at %s", entry.IP, entry.Timestamp)
+			log.Printf("🔄 Processing entry %d/%d: IP %s at %s", i+1, len(entries), entry.IP, entry.Timestamp)
 
+			sendStart := time.Now()
 			if err := grpcclient.SendLog(grpcAddress, entry.IP, entry.Timestamp); err != nil {
-				log.Printf("gRPC send failed: %v", err)
+				log.Printf("❌ gRPC send failed for IP %s: %v", entry.IP, err)
+			} else {
+				log.Printf("✅ Successfully sent log for IP %s (took %v)", entry.IP, time.Since(sendStart))
 			}
 
 			// Update the offset after processing each entry
-			if err := state.WriteOffset(offsetPath, offset+int64(i+1)); err != nil {
-				log.Printf("Failed to write offset: %v", err)
+			if err := state.WriteOffset(offsetPath, currentOffset+1); err != nil {
+				log.Printf("⚠️ Failed to update offset to %d: %v", currentOffset+1, err)
+			} else if i%10 == 0 || i == len(entries)-1 { // Log every 10th update or the final one
+				log.Printf("💾 Offset updated to %d", currentOffset+1)
 			}
 		}
+	}
+
+	processingTime := time.Since(startTime)
+	log.Printf("✅ Processing complete! Processed %d entries in %v", len(entries), processingTime)
+	if len(entries) > 0 {
+		log.Printf("📈 Average processing time: %v per entry", processingTime/time.Duration(len(entries)))
 	}
 }

--- a/ssh-log-monitor/state/offset.go
+++ b/ssh-log-monitor/state/offset.go
@@ -1,9 +1,31 @@
 package state
 
 import (
+	"errors"
 	"os"
 	"strconv"
 )
+
+const lockFilePath = "process.lock"
+
+// AcquireLock creates a lock file to prevent concurrent runs.
+// Returns an error if the lock file already exists.
+func AcquireLock() error {
+	if _, err := os.Stat(lockFilePath); err == nil {
+		return errors.New("another process is already running")
+	}
+	file, err := os.Create(lockFilePath)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	return nil
+}
+
+// ReleaseLock removes the lock file.
+func ReleaseLock() error {
+	return os.Remove(lockFilePath)
+}
 
 // ReadOffset reads the offset from the given file path.
 // If the file does not exist, it returns 0.


### PR DESCRIPTION
## Summary
Enhanced SSH Log Monitor to handle large backlogs and prevent duplicate processing.

## Key Changes
- Added 5-minute timeout to match cron interval
- Implemented incremental offset updates after each log entry
- Added file-based locking to prevent concurrent runs
- Enhanced logging with performance metrics
- Updated documentation

## Benefits
- No duplicate log processing
- Graceful handling of large backlogs
- Better visibility through improved logs
- Automatic recovery from interruptions

### Example logs:

```
2025/04/09 18:35:35 ⏱️ Set execution timeout: 5m0s
2025/04/09 18:35:35 🔒 Attempting to acquire lock...
2025/04/09 18:35:35 ✅ Lock acquired successfully
2025/04/09 18:35:35 📋 Read offset: 0 from offset.txt
2025/04/09 18:35:35 📖 Parsing auth log from /var/log/auth.log starting at offset 0...
🎯 MATCH FOUND: 83.82.26.140 at 2025-04-09T18:35:21.538460+02:00 ----- DIT WAS IK
🔁 REPEATED MATCH FOUND: 83.82.26.140 at 2025-04-09T18:35:29.478070+02:00
2025/04/09 18:35:35 📊 Scan complete - Found 2 entries | New offset: 29
2025/04/09 18:35:35 🔍 Found 2 SSH login attempts to process
➡️ Found SSH login attempt from IP 83.82.26.140 at 2025-04-09T18:35:21.538460+02:00
➡️ Found SSH login attempt from IP 83.82.26.140 at 2025-04-09T18:35:29.478070+02:00
2025/04/09 18:35:35 🔄 Processing entry 1/2: IP 83.82.26.140 at 2025-04-09T18:35:21.538460+02:00
2025/04/09 18:35:35 ✅ Successfully sent log for IP 83.82.26.140 (took 216.923879ms)
2025/04/09 18:35:35 💾 Offset updated to 1
2025/04/09 18:35:35 🔄 Processing entry 2/2: IP 83.82.26.140 at 2025-04-09T18:35:29.478070+02:00
2025/04/09 18:35:35 ✅ Successfully sent log for IP 83.82.26.140 (took 121.496169ms)
2025/04/09 18:35:35 💾 Offset updated to 2
2025/04/09 18:35:35 ✅ Processing complete! Processed 2 entries in 340.363504ms
2025/04/09 18:35:35 📈 Average processing time: 170.181752ms per entry
2025/04/09 18:35:35 🔓 Lock released successfully 
```